### PR TITLE
Allowed adding routes without leading slash

### DIFF
--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -46,7 +46,7 @@ export class SitemapContext {
   }
 
   add(route: string) {
-    this.#routes.push(route);
+    this.#routes.push(route.replace(/(^\/?)|(\/?$)/, '/'));
     return this;
   }
 

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -165,7 +165,7 @@ Deno.test("Add additional routes", () => {
   };
   const sitemap = new SitemapContext(url, manifest);
 
-  const result = sitemap.add("/blog/hello-world").generate();
+  const result = sitemap.add("/blog/hello-world").add("help").generate();
 
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
@@ -174,6 +174,7 @@ Deno.test("Add additional routes", () => {
   );
 
   assertStringIncludes(result, "<loc>https://deno.land/blog/hello-world</loc>");
+  assertStringIncludes(result, "<loc>https://deno.land/help</loc>");
 
   assertStringIncludes(result, "</urlset>");
 });


### PR DESCRIPTION
Now when you add a route it is automatically prepended by a slash. This closes #9.