### PR TITLE
Add editable lastmod&changefreq&priority to SitemapContext

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -1,4 +1,4 @@
-import { join, resolve, ensureFile } from "./src/deps.ts";
+import { ensureFile, join, resolve } from "./src/deps.ts";
 
 const routesDirectory = resolve("./routes");
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,5 +1,14 @@
-export { default as day} from "https://esm.sh/dayjs@1.11.5";
-export { basename, extname, join, resolve } from "https://deno.land/std@0.153.0/path/mod.ts";
-export { assert, assertStringIncludes, assertThrows } from "https://deno.land/std@0.145.0/testing/asserts.ts";
+export { default as day } from "https://esm.sh/dayjs@1.11.5";
+export {
+  basename,
+  extname,
+  join,
+  resolve,
+} from "https://deno.land/std@0.153.0/path/mod.ts";
+export {
+  assert,
+  assertStringIncludes,
+  assertThrows,
+} from "https://deno.land/std@0.145.0/testing/asserts.ts";
 export { FakeTime } from "https://deno.land/std@0.145.0/testing/time.ts";
 export { ensureFile } from "https://deno.land/std@0.128.0/fs/mod.ts";

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -4,14 +4,14 @@
 /// <reference lib="deno.ns" />
 /// <reference lib="deno.unstable" />
 
-import { basename, extname, day } from "./deps.ts";
-import { type Manifest } from "./types.ts";
+import { basename, day, extname } from "./deps.ts";
+import { type Manifest, type Route, type RouteProps } from "./types.ts";
 
 export class SitemapContext {
   #url: string;
   #manifest: Manifest;
   #globalIgnore = ["sitemap.xml"];
-  #routes: Array<string> = [];
+  #routes: Array<Route> = [];
 
   constructor(url: string, manifest: Manifest) {
     this.#url = url;
@@ -24,7 +24,8 @@ export class SitemapContext {
         const isDynamic = !!fileName.match(/^\[.+\]$/)?.length;
 
         if (
-          isDynamic || fileName.startsWith("_") ||
+          isDynamic ||
+          fileName.startsWith("_") ||
           this.#globalIgnore.includes(fileName)
         ) {
           return false;
@@ -33,40 +34,71 @@ export class SitemapContext {
         return true;
       })
       .map(([path, route]) => {
-        return path
-          .replace(extname(path), "")
-          .replace("./routes", "")
-          .replace("index", ""); // We remove index as it's consider a "/" in Fresh
-      })
+        return {
+          pathName: path
+            .replace(extname(path), "")
+            .replace("./routes", "")
+            .replace("index", ""), // We remove index as it's consider a "/" in Fresh
+        };
+      });
   }
 
   get routes() {
     return this.#routes;
   }
 
-  add(route: string) {
-    this.#routes.push(route.replace(/(^\/?)|(\/?$)/, '/'));
+  add(route: string, props?: RouteProps) {
+    if (typeof props === "undefined") {
+      this.#routes.push({
+        pathName: route.replace(/(^\/?)|(\/?$)/, "/"),
+      });
+      return this;
+    }
+    const { changefreq, priority, lastmod } = props;
+    this.#routes.push({
+      pathName: route.replace(/(^\/?)|(\/?$)/, "/"),
+      changefreq,
+      priority,
+      lastmod,
+    });
+    return this;
+  }
+
+  set(route: string, props?: RouteProps) {
+    if (typeof props === "undefined") return this;
+    const i = this.#routes.findIndex(
+      (v) => v.pathName === route.replace(/(^\/?)|(\/?$)/, "/")
+    );
+    if (i === -1) return this;
+    const { changefreq, priority, lastmod } = props;
+    const currentRoute = this.#routes[i];
+    this.#routes[i] = {
+      ...currentRoute,
+      changefreq: changefreq ?? currentRoute.changefreq,
+      priority: priority ?? currentRoute.priority,
+      lastmod: lastmod ?? currentRoute.lastmod,
+    };
     return this;
   }
 
   remove(route: string) {
-    this.#routes = this.#routes.filter(r => r !== route);
+    this.#routes = this.#routes.filter((r) => r.pathName !== route);
     return this;
   }
 
   generate() {
     return `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-      ${this.routes.map((route) => {
-      return `<url>
-          <loc>${this.#url}${route}</loc>
-          <lastmod>${day().format("YYYY-MM-DD")}</lastmod>
-          <changefreq>daily</changefreq>
-          <priority>0.8</priority>
+      ${this.routes
+        .map((route) => {
+          return `<url>
+          <loc>${this.#url}${route.pathName}</loc>
+          <lastmod>${day(route.lastmod).format("YYYY-MM-DD")}</lastmod>
+          <changefreq>${route.changefreq ?? "daily"}</changefreq>
+          <priority>${route.priority ?? "0.8"}</priority>
         </url>`;
-    })
-        .join("\n")
-      }
+        })
+        .join("\n")}
     </urlset>`;
   }
 

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -67,7 +67,7 @@ export class SitemapContext {
   set(route: string, props?: RouteProps) {
     if (typeof props === "undefined") return this;
     const i = this.#routes.findIndex(
-      (v) => v.pathName === route.replace(/(^\/?)|(\/?$)/, "/")
+      (v) => v.pathName === route.replace(/(^\/?)|(\/?$)/, "/"),
     );
     if (i === -1) return this;
     const { changefreq, priority, lastmod } = props;
@@ -89,7 +89,8 @@ export class SitemapContext {
   generate() {
     return `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-      ${this.routes
+      ${
+      this.routes
         .map((route) => {
           return `<url>
           <loc>${this.#url}${route.pathName}</loc>
@@ -98,7 +99,8 @@ export class SitemapContext {
           <priority>${route.priority ?? "0.8"}</priority>
         </url>`;
         })
-        .join("\n")}
+        .join("\n")
+    }
     </urlset>`;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,42 @@
 // deno-lint-ignore-file no-explicit-any
 
 export interface Manifest {
-  routes: Record<string,any>;
+  routes: Record<string, any>;
   islands: Record<string, any>;
   baseUrl: string;
 }
+
+export interface Route {
+  pathName: string;
+  changefreq?: ChangeFrequency;
+  priority?: Priority;
+  lastmod?: Date;
+}
+
+export interface RouteProps {
+  changefreq?: ChangeFrequency;
+  priority?: Priority;
+  lastmod?: Date;
+}
+
+export type ChangeFrequency =
+  | "always"
+  | "hourly"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "yearly"
+  | "never";
+
+export type Priority =
+  | "0.0"
+  | "0.1"
+  | "0.2"
+  | "0.3"
+  | "0.4"
+  | "0.5"
+  | "0.6"
+  | "0.7"
+  | "0.8"
+  | "0.9"
+  | "1.0";

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -24,7 +24,7 @@ Deno.test("Empty sitemap", () => {
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
     result,
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
   );
   assertStringIncludes(result, "</urlset>");
 });
@@ -46,7 +46,7 @@ Deno.test("Map root index.ts", () => {
     assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
     assertStringIncludes(
       result,
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     );
 
     assertStringIncludes(result, `<loc>https://deno.land/</loc>`);
@@ -76,7 +76,7 @@ Deno.test("Map static route file", () => {
     assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
     assertStringIncludes(
       result,
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     );
 
     assertStringIncludes(result, `<loc>https://deno.land/dashboard</loc>`);
@@ -108,7 +108,7 @@ Deno.test("Ignore special routes file starting with _", () => {
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
     result,
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
   );
 
   assert(!result.includes(`<loc>https://deno.land/_404</loc>`));
@@ -151,7 +151,7 @@ Deno.test("Ignore sitemap.xml route", () => {
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
     result,
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
   );
 
   assert(!result.includes(`<loc>https://deno.land/sitemap.xml</loc>`));
@@ -179,7 +179,7 @@ Deno.test("Add additional routes", () => {
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
     result,
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
   );
 
   assertStringIncludes(result, "<loc>https://deno.land/blog/hello-world</loc>");
@@ -207,7 +207,7 @@ Deno.test("Remove certain routes", () => {
   assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
   assertStringIncludes(
     result,
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
   );
 
   assertThrows(() =>
@@ -237,7 +237,7 @@ Deno.test("Set current route", async (t) => {
     assertStringIncludes(result, '<?xml version="1.0" encoding="UTF-8"?>');
     assertStringIncludes(
       result,
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     );
 
     assertStringIncludes(result, "<loc>https://deno.land/help</loc>");


### PR DESCRIPTION
## Background 
Lastmod, changefreq, and priority attribute values are fixed like below currently.
- lastmod: The day site to be accessed
- changefreq: "daily"
- priority: "0.8"

If they are editable, users may be happier.

## What changed
- Adding `RouteProps` param to SitemapContext@add method then user can select their preferred attribute values.
- Adding `set` method to SitemapContext then user can edit existing routes' attribute values.
- Adding relevant tests

## Note
I did use `deno fmt` but some formats have been changed.
I was only in purpose of changing `sitemap.ts`, `types.ts` and `sitemap.test.ts`