### PR TITLE
Introducing `<Meta />` Component to help users manage meta Infos

### DIFF
--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -1,0 +1,29 @@
+import { MetaProps } from "../src/meta.ts";
+
+export default function Meta({ metaProps }: { metaProps: MetaProps }) {
+  const { description, title, url, keywords, imageUrl, type } = metaProps;
+  return (
+    <>
+      {description
+        ? (
+          <>
+            <meta name="description" content={description} />
+            <meta property="og:description" content={description} />
+          </>
+        )
+        : null}
+      {title
+        ? (
+          <>
+            <title>{title}</title>
+            <meta property="og:title" content={title} />
+          </>
+        )
+        : null}
+      {keywords ? <meta name="keywords" content={keywords} /> : null}
+      <meta property="og:url" content={url} />
+      {type ? <meta property="og:type" content={type} /> : null}
+      {imageUrl ? <meta property="og:image" content={imageUrl} /> : null}
+    </>
+  );
+}

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,10 @@
 {
   "tasks": {
     "test": "deno test --allow-env --allow-write --allow-read"
+  },
+  "importMap": "./import_map.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,6 @@
   "tasks": {
     "test": "deno test --allow-env --allow-write --allow-read"
   },
-  "importMap": "./import_map.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "preact"

--- a/src/initFile.ts
+++ b/src/initFile.ts
@@ -1,4 +1,4 @@
-import { ensureFile, join, resolve } from "./deps.ts";
+import { ensureFile, extname, join, resolve } from "./deps.ts";
 
 function isUrl(input: string): boolean {
   try {
@@ -41,10 +41,7 @@ export const handler: Handlers = {
   return Deno.writeTextFile(destination, stub);
 }
 
-async function createRobotTxt(
-  url: string,
-  staticPath: string,
-) {
+async function createRobotTxt(url: string, staticPath: string) {
   const directory = resolve(staticPath);
 
   const destination = join(directory, "robots.txt");
@@ -58,6 +55,46 @@ Sitemap: ${url}/sitemap.xml
 `;
 
   return Deno.writeTextFile(destination, stub);
+}
+
+async function createSeoConfig() {
+  const routes: string[] = [];
+  for await (const dirEntry of Deno.readDir("./routes")) {
+    if (dirEntry.isFile) {
+      const fileName = dirEntry.name.replace(extname(dirEntry.name), "");
+      const isDynamic = !!fileName.match(/^\[.+\]$/)?.length;
+      if (
+        isDynamic ||
+        fileName.startsWith("_") ||
+        fileName.startsWith("sitemap")
+      ) {
+        continue;
+      }
+      routes.push(fileName);
+    }
+  }
+  const routesText = routes.map((route) => {
+    if (route === "index") {
+      return `"/": {
+      title: "index",
+      description: "${route} page",
+    }`;
+    }
+    return `
+    "/${route}": {
+      title: "${route}",
+      description: "${route} page",
+    }`;
+  });
+  const stub =
+    `import { Config } from "https://deno.land/x/fresh_seo@0.2.1/mod.ts";
+export default {
+  routes: {
+    ${routesText.join(",")}
+  },
+} as Config;
+  `;
+  return Deno.writeTextFile("./fresh-seo.config.ts", stub);
 }
 
 export async function init() {
@@ -86,4 +123,5 @@ export async function init() {
   await createSitemap(url);
 
   await createRobotTxt(url, staticPath);
+  await createSeoConfig();
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,0 +1,24 @@
+import { Config } from "./types.ts";
+
+export interface MetaProps {
+  title?: string;
+  description?: string;
+  keywords?: string;
+  imageUrl?: string;
+  type?: string;
+  url?: string;
+}
+
+export function getMetaProps(config: Config, req: Request): MetaProps {
+  const reqUrl = new URL(req.url);
+  const { description, title, keywords, imageUrl, type, url } =
+    config.routes[reqUrl.pathname];
+  return {
+    description,
+    title,
+    keywords,
+    imageUrl,
+    url: url ?? reqUrl.href,
+    type,
+  };
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,1 +1,3 @@
 export { SitemapContext } from "./sitemap.ts";
+export * from "./meta.ts";
+export type { Config } from "./types.ts";

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -94,7 +94,7 @@ export class SitemapContext {
         .map((route) => {
           return `<url>
           <loc>${this.#url}${route.pathName}</loc>
-          <lastmod>${formatYearMonthDate(route.lastmod??new Date())}</lastmod>
+          <lastmod>${formatYearMonthDate(route.lastmod ?? new Date())}</lastmod>
           <changefreq>${route.changefreq ?? "daily"}</changefreq>
           <priority>${route.priority ?? "0.8"}</priority>
         </url>`;
@@ -128,6 +128,8 @@ export class SitemapContext {
 
 function formatYearMonthDate(date: Date) {
   return `${date.getFullYear()}-${("00" + (date.getMonth() + 1)).slice(-2)}-${
-    ("00" + date.getDate()).slice(-2)
+    (
+      "00" + date.getDate()
+    ).slice(-2)
   }`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
+import { MetaProps } from "./meta.ts";
 
 export interface Manifest {
   routes: Record<string, any>;
@@ -40,3 +41,7 @@ export type Priority =
   | "0.8"
   | "0.9"
   | "1.0";
+
+export interface Config {
+  routes: Record<string, MetaProps>;
+}


### PR DESCRIPTION
## Background
#10 

## What changed
1. Introducing <Meta /> Component
2. Adding generation of fresh-seo.config.ts which includes meta config.

## Usage

### 1. run init.ts script
This generates fresh-seo.config.ts from user's `routes/`
```ts
//fresh-seo.config.ts
import { Config } from "fresh-seo";
export default {
  routes: {
    "/": {
      title: "index",
      description: "index page",
    },
    "/about": {
      title: "about",
      description: "about page",
    },
  },
} as Config;

```
### 2. Add `<Meta />` and related imports to page route components
```tsx
//index.ts
import { Handlers, PageProps } from "$fresh/server.ts";
import { Head } from "$fresh/runtime.ts";
import seoConfig from "../fresh-seo.config.ts";
import { MetaProps, getMetaProps } from "fresh-seo";
import Meta from "fresh-seo/components";

interface Props {
  metaProps: MetaProps;
}

export const handler: Handlers = {
  GET(req, ctx) {
    const metaProps = getMetaProps(seoConfig, req);
    return ctx.render({ metaProps });
  },
};

 export default function Home({ data }: PageProps<Props>) {
  return (
    <>
      <Head>
        <Meta metaProps={data.metaProps} />
      </Head>
      <div>
     {/* body */}
      </div>
    </>
  );
}
```
[sample project](https://github.com/sinyo-matu/fresh-seo-plugin-demo) with [demo](https://fresh-seo-plugin-demo.deno.dev/)

Maybe this inflicts too much user effort :thinking:
What do you think?
