### PR TITLE
HOTFIX: Fixed sitemap not working properly

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,7 @@ export const freshSEOPlugin = (manifest: Manifest, opts: PluginOptions = {}): Pl
 			{
 				path: "/sitemap.xml",
 				handler: (req) => {
-					const sitemap = new SitemapContext(req.url, manifest);
+					const sitemap = new SitemapContext(req.url.replace("/sitemap.xml", ""), manifest);
 
 					if (opts.include) {
 						opts.include.forEach((route) => {


### PR DESCRIPTION
I left out a very important bit in the code, the Request URL that is used in the `sitemap.xml` route created by the plugin also includes the `/sitemap.xml` part. That should be removed. This patch fixes it.

Edit: How could we create tests for the plugin?